### PR TITLE
Fix default_socket

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,9 @@ RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.ustc.edu.cn/g' /etc/apk/repositorie
     && mv /tmp/docker-php-entrypoint /usr/local/bin/docker-php-entrypoint \
     && chmod +x /usr/local/bin/docker-php-entrypoint \
     && mv /tmp/nginx.conf /etc/nginx/nginx.conf \
-    && chown -R www-data:www-data /var/www/html \
+    && chown -R www-data:www-data /var/www/html \    
+    && mv /tmp/docker-php-ext-mysqli.ini /usr/local/etc/php/conf.d \
+    && mv /tmp/docker-php-ext-pdo_mysql.ini /usr/local/etc/php/conf.d \
     # clear
     && rm -rf /var/www/html/db.sql \
     && rm -rf /tmp/*

--- a/_files/docker-php-ext-mysqli.ini
+++ b/_files/docker-php-ext-mysqli.ini
@@ -1,0 +1,2 @@
+extension=mysqli.so
+mysqli.default_socket = /run/mysqld/mysqld.sock

--- a/_files/docker-php-ext-pdo_mysql.ini
+++ b/_files/docker-php-ext-pdo_mysql.ini
@@ -1,0 +1,2 @@
+extension=pdo_mysql.so
+pdo_mysql.default_socket = /run/mysqld/mysqld.sock


### PR DESCRIPTION
Fix PHP default socket error on Alpine Linux Docker.
Default value is "/tmp/mysqld.sock",but it should be "/run/mysqld/mysqld.sock" or "/var/run/mysqld/mysqld.sock".I just add one line on both PHP's pdo_mysql and mysqli conf file.